### PR TITLE
rdke 92 include vendor pkg versions halif

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -1,4 +1,5 @@
 # This layer shall be common for all RPi variants.
+require conf/include/vendor_pkg_versions_halif_impl.inc
 
 PV_pn-packagegroup-vendor-layer = "1.0.0"
 PR_pn-packagegroup-vendor-layer = "r0"


### PR DESCRIPTION
included vendor_pkg_versions_halif_impl.inc as part of vendor_pkg_versions.inc in vendor release layer.