### PR TITLE
RDKE-100: Fix Nothing provides error for foundation layer recipes

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -79,7 +79,10 @@ MACHINE_FEATURES += "apm usbhost keyboard vfat ext2 screen touchscreen alsa blue
 # Raspberry Pi has no hardware clock
 MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"
 
-MACHINE_EXTRA_RRECOMMENDS += "kernel-modules udev-rules-rpi"
+#RDKE-100: Commenting to resolve nothing provides err with packagegroup-base(foundation-layer)
+#MACHINE_EXTRA_RRECOMMENDS += "kernel-modules udev-rules-rpi"
+MACHINE_EXTRA_RRECOMMENDS += "kernel-modules"
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "${@oe.utils.conditional('ENABLE_I2C', '1', 'kernel-module-i2c-dev kernel-module-i2c-bcm2708', '', d)}"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "${@oe.utils.conditional('ENABLE_IR', '1', 'kernel-module-gpio-ir kernel-module-gpio-ir-tx', '', d)}"
 

--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -5,10 +5,11 @@
 MACHINEOVERRIDES = "raspberrypi4:${MACHINE}"
 
 MACHINE_FEATURES += "pci"
-MACHINE_EXTRA_RRECOMMENDS += "\
-    linux-firmware-rpidistro-bcm43455 \
-    bluez-firmware-rpidistro-bcm4345c0-hcd \
-"
+# RDKE-100 - Commenting to resolve Nothing provides error with packagegroup-base
+#MACHINE_EXTRA_RRECOMMENDS += "\
+#    linux-firmware-rpidistro-bcm43455 \
+#    bluez-firmware-rpidistro-bcm4345c0-hcd \
+#"
 
 require conf/machine/include/tune-cortexa72.inc
 include conf/machine/include/rpi-base.inc
@@ -35,3 +36,5 @@ RPI_EXTRA_CONFIG ?= "\n# Force arm in 64bit mode. See: https://github.com/raspbe
 
 ARMSTUB ?= "armstub8-gic.bin"
 
+WHITELIST_GPLv3 += "${MLPREFIX}dosfstools ${MLPREFIX}coreutils ${MLPREFIX}findutils"
+WHITELIST_GPL-3.0 = "${WHITELIST_GPLv3}"


### PR DESCRIPTION
Reason for change: Fixes build issues with rpi specific package dependencies for foundation layer
* packagegorup-base (linux-firmware-rpidistro, bluez-firmware-rpidistro, udev-rules-rpi) are commented
* GPLv3 packages - dosfstools, coreutils, findutils are whitelisted Test Procedure: Build and verify
Risks: Low
Priority: P1