### PR TITLE
Remove mpg123 from vendor

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -73,10 +73,6 @@ PV_pn-librsvg = "2.40.21"
 PR_pn-librsvg = "r0"
 PACKAGE_ARCH_pn-lib32-librsvg = "${VENDOR_LAYER_EXTENSION}"
 
-PV_pn-mpg123 = "1.25.13"
-PR_pn-mpg123 = "r0"
-PACKAGE_ARCH_pn-lib32-mpg123 = "${VENDOR_LAYER_EXTENSION}"
-
 PV_pn-pango = "1.44.7"
 PR_pn-pango = "r0"
 PACKAGE_ARCH_pn-lib32-pango = "${VENDOR_LAYER_EXTENSION}"


### PR DESCRIPTION
Middleware layer sets this component with PACKAGE_ARCH MIDDLEWARE_ARCH Removing it from vendor layer