### PR TITLE
RDKE-127: Add systemd distro check for rpi_generate_sysctl_config

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -199,13 +199,16 @@ IMAGE_CMD_rpi-sdimg () {
 ROOTFS_POSTPROCESS_COMMAND += " rpi_generate_sysctl_config ; "
 
 rpi_generate_sysctl_config() {
-    # systemd sysctl config
-    test -d ${IMAGE_ROOTFS}${sysconfdir}/sysctl.d && \
-        echo "vm.min_free_kbytes = 8192" > ${IMAGE_ROOTFS}${sysconfdir}/sysctl.d/rpi-vm.conf
-
-    # sysv sysctl config
-    IMAGE_SYSCTL_CONF="${IMAGE_ROOTFS}${sysconfdir}/sysctl.conf"
-    test -e ${IMAGE_ROOTFS}${sysconfdir}/sysctl.conf && \
-        sed -e "/vm.min_free_kbytes/d" -i ${IMAGE_SYSCTL_CONF}
-    echo "" >> ${IMAGE_SYSCTL_CONF} && echo "vm.min_free_kbytes = 8192" >> ${IMAGE_SYSCTL_CONF}
+    if [ "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}" = "true" ]
+    then
+         # systemd sysctl config
+         test -d ${IMAGE_ROOTFS}${sysconfdir}/sysctl.d && \
+             echo "vm.min_free_kbytes = 8192" > ${IMAGE_ROOTFS}${sysconfdir}/sysctl.d/rpi-vm.conf
+    else
+         # sysv sysctl config
+         IMAGE_SYSCTL_CONF="${IMAGE_ROOTFS}${sysconfdir}/sysctl.conf"
+         test -e ${IMAGE_ROOTFS}${sysconfdir}/sysctl.conf && \
+             sed -e "/vm.min_free_kbytes/d" -i ${IMAGE_SYSCTL_CONF}
+         echo "" >> ${IMAGE_SYSCTL_CONF} && echo "vm.min_free_kbytes = 8192" >> ${IMAGE_SYSCTL_CONF}
+    fi
 }


### PR DESCRIPTION
Reason for change: As per RDK-45498, no individual component must install their own sysctl conf files into /etc/sysctl.conf , allowing that can potentially override other settings.  Components can install the conf in /etc/sysctl.d/ path. Test Procedure: Ensure build is success
Risks: Medium