### PR TITLE
RDKE-115: Update dropbearkey path for Rpi

### DIFF
--- a/recipes-release/images/middleware-generic-test-image.bbappend
+++ b/recipes-release/images/middleware-generic-test-image.bbappend
@@ -1,0 +1,6 @@
+ROOTFS_POSTPROCESS_COMMAND += "update_dropbearkey_path; "
+update_dropbearkey_path() {
+   if [ -f "${IMAGE_ROOTFS}/lib/systemd/system/dropbeakey.service" ]; then
+        sed -i 's/\/etc\dropbear/\/opt\dropbear/g' ${IMAGE_ROOTFS}/lib/systemd/system/dropbearkey.service
+   fi
+}


### PR DESCRIPTION
Reason for change: default dropbear keypath is readonly, change to read/write path
Test procedure: Build and verify dropbear ssh
Risks: Low