### PR TITLE
REFPLTV-2309: hdmicec implementation for RPI

### DIFF
--- a/conf/include/rdke-vendor-bbmask.inc
+++ b/conf/include/rdke-vendor-bbmask.inc
@@ -9,6 +9,5 @@ BBMASK += " meta-openembedded/meta-oe/recipes-devtools/breakpad/breakpad_svn.bb"
 
 #From meta-rdk-halif-headers
 # FIXME: unmask as integration progresses
-BBMASK += " meta-rdk-halif-headers/recipes-rdk-halif-headers/hdmicec"
 BBMASK += " meta-rdk-halif-headers/recipes-rdk-halif-headers/tvsettings"
 


### PR DESCRIPTION
Removed the BBMASK hdmicec hal headers.