### PR TITLE
OTA image creation support

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -4,6 +4,10 @@ include conf/machine/include/soc-family.inc
 IMAGE_FSTYPES ?= "tar.bz2 ext3 wic.bz2 wic.bmap"
 WKS_FILE ?= "sdimage-raspberrypi.wks"
 
+# Support for RPI RDK OTA Image
+IMAGE_FSTYPES += " wic"
+include conf/machine/include/rpi-ota-image.inc
+
 # Source: RPI Default Settings, for FS Creation.
 IMAGE_CLASSES += "sdcard_image-rpi"
 

--- a/conf/machine/include/rpi-ota-image.inc
+++ b/conf/machine/include/rpi-ota-image.inc
@@ -1,0 +1,81 @@
+# The RDK OTA image for RPi - creation logic
+#
+# The function do_create_ota_image_wic requires uncompressed 'wic' image created matching IMAGE_BASENAME.
+# It copies ${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}*.wic as ${OTA_IMAGE_NAME} and
+# deletes the PARTITIONS 3 & 4 which are added by 'wic/sdimage-raspberrypi.wks' as /root2 and /persist.
+# Then it truncates ${OTA_IMAGE_NAME} to save space by adding only /boot and /root1 in the OTA package.
+
+OTA_IMAGE_NAME ?= "${MACHINE_IMAGE_NAME}-${IMAGE_BASENAME}-ota-image.wic"
+
+python do_create_ota_image_wic() {
+    import os
+    import subprocess
+    import tarfile
+    from bb import note, error
+
+    deploy_dir_image = d.getVar('DEPLOY_DIR_IMAGE')
+    image_basename = d.getVar('IMAGE_BASENAME')
+    ota_image_name = d.getVar('OTA_IMAGE_NAME')
+    ota_tar_gz_name = ota_image_name + ".tar.gz"
+
+    # Find the generated WIC image
+    wic_image = None
+    for file in os.listdir(deploy_dir_image):
+        if file.startswith(image_basename) and file.endswith('.wic'):
+            wic_image = os.path.join(deploy_dir_image, file)
+            break
+
+    if not wic_image:
+        error("Not able to find {}-*.wic for OTA image creation.".format(image_basename))
+        return 1
+
+    # Create a copy of the uncompressed WIC image
+    ota_wic_image = os.path.join(deploy_dir_image, ota_image_name)
+    note("Using {} for creating {}...".format(wic_image, ota_wic_image))
+    subprocess.run(['cp', wic_image, ota_wic_image], check=True)
+
+    # Remove /root2 and /opt partitions
+    size_before = os.path.getsize(ota_wic_image)
+    note("Size of {} before deleting partitions: {} bytes".format(ota_wic_image, size_before))
+
+    partitions = subprocess.check_output(['parted', '-s', ota_wic_image, 'print']).decode('utf-8')
+    for line in partitions.splitlines():
+        if line.startswith(' '):
+            parts = line.split()
+            part_num = parts[0]
+            part_name = parts[-1]
+            if part_name in ["root2", "persist"] or part_num in ["3", "4"]:
+                note("Deleting partition {} with label {}...".format(part_num, part_name))
+                subprocess.run(['sfdisk', '--delete', ota_wic_image, part_num], check=True)
+
+    # Calculate the end sector of the last remaining partition
+    end_sector_output = subprocess.check_output(['parted', '-s', ota_wic_image, 'print']).decode('utf-8')
+    end_sector_str = [line.split()[2] for line in end_sector_output.splitlines() if ' 2 ' in line][0]
+
+    # Convert end_sector_str to sectors
+    if end_sector_str.endswith('KB'):
+        end_sector = int(float(end_sector_str[:-2]) * 1024 / 512)
+    elif end_sector_str.endswith('MB'):
+        end_sector = int(float(end_sector_str[:-2]) * 1024 * 1024 / 512)
+    elif end_sector_str.endswith('GB'):
+        end_sector = int(float(end_sector_str[:-2]) * 1024 * 1024 * 1024 / 512)
+    else:
+        end_sector = int(end_sector_str.replace('s', ''))
+
+    note("Calculated end_sector is {}.".format(end_sector))
+
+    # Truncate the OTA_WIC_IMAGE to the end of the last remaining partition using Python
+    with open(ota_wic_image, 'r+b') as f:
+        f.truncate(end_sector * 512)
+
+    size_after = os.path.getsize(ota_wic_image)
+    note("Size of {} after deleting partitions and truncating: {} bytes".format(ota_wic_image, size_after))
+
+    ota_tar_gz_path = os.path.join(deploy_dir_image, ota_tar_gz_name)
+    with tarfile.open(ota_tar_gz_path, "w:gz") as tar:
+        tar.add(ota_wic_image, arcname=os.path.basename(ota_wic_image))
+
+    note("Compressed OTA image created successfully: {}".format(ota_tar_gz_path))
+}
+
+addtask do_create_ota_image_wic after do_image_complete before do_populate_lic_deploy

--- a/wic/sdimage-raspberrypi.wks
+++ b/wic/sdimage-raspberrypi.wks
@@ -3,4 +3,6 @@
 # Raspberry Pi. Boot files are located in the first vfat partition.
 
 part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 20
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 4096
+part /root1 --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root1 --align 4096 --size 1024
+part /root2 --ondisk mmcblk0 --fstype=ext4 --label root2 --align 4096 --size 1024
+part /opt --ondisk mmcblk0 --fstype=ext4 --label persist --align 4096 --size 4096


### PR DESCRIPTION
- Modified the normal WIC image with below partitions for initial SDCard preparation
- - /boot (default)
- - /root1 (default rootfs)
- - /root2 (empty rootfs)
- - /opt (persistant)
- OTA image will be created from WIC image as ${MACHINE_IMAGE_NAME}-${IMAGE_BASENAME}-ota-image.wic