### PR TITLE
Disable OTA WIC generation to fix MW build error.

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -5,8 +5,8 @@ IMAGE_FSTYPES ?= "tar.bz2 ext3 wic.bz2 wic.bmap"
 WKS_FILE ?= "sdimage-raspberrypi.wks"
 
 # Support for RPI RDK OTA Image
-IMAGE_FSTYPES += " wic"
-include conf/machine/include/rpi-ota-image.inc
+##IMAGE_FSTYPES += " wic"
+##include conf/machine/include/rpi-ota-image.inc
 
 # Source: RPI Default Settings, for FS Creation.
 IMAGE_CLASSES += "sdcard_image-rpi"


### PR DESCRIPTION
Disable OTA image generation logic to stabilize the MW build.