### PR TITLE
RDKVREFPLT-3151: refactor ota creation support

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -5,8 +5,8 @@ IMAGE_FSTYPES ?= "tar.bz2 ext3 wic.bz2 wic.bmap"
 WKS_FILE ?= "sdimage-raspberrypi.wks"
 
 # Support for RPI RDK OTA Image
-##IMAGE_FSTYPES += " wic"
-##include conf/machine/include/rpi-ota-image.inc
+IMAGE_FSTYPES += " wic"
+include conf/machine/include/rpi-ota-image.inc
 
 # Source: RPI Default Settings, for FS Creation.
 IMAGE_CLASSES += "sdcard_image-rpi"

--- a/conf/machine/include/rpi-ota-image.inc
+++ b/conf/machine/include/rpi-ota-image.inc
@@ -78,4 +78,5 @@ python do_create_ota_image_wic() {
     note("Compressed OTA image created successfully: {}".format(ota_tar_gz_path))
 }
 
-addtask do_create_ota_image_wic after do_image_complete before do_populate_lic_deploy
+addtask do_create_ota_image_wic after do_image do_rootfs_wicenv do_image_wic do_image_complete before do_populate_lic_deploy
+

--- a/conf/machine/include/rpi-ota-image.inc
+++ b/conf/machine/include/rpi-ota-image.inc
@@ -78,5 +78,11 @@ python do_create_ota_image_wic() {
     note("Compressed OTA image created successfully: {}".format(ota_tar_gz_path))
 }
 
-addtask do_create_ota_image_wic after do_image do_rootfs_wicenv do_image_wic do_image_complete before do_populate_lic_deploy
+addtask do_create_ota_image_wic after do_image_complete before do_populate_lic_deploy
+do_create_ota_image_wic[recrdeps] = "do_build"
+do_create_ota_image_wic[depends] += " \
+    virtual/kernel:do_deploy \
+    rpi-bootfiles:do_deploy \
+    ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
+    "
 

--- a/conf/machine/include/rpi-ota-image.inc
+++ b/conf/machine/include/rpi-ota-image.inc
@@ -78,7 +78,7 @@ python do_create_ota_image_wic() {
     note("Compressed OTA image created successfully: {}".format(ota_tar_gz_path))
 }
 
-addtask do_image_wic after do_image_complete do_rootfs before do_build
+addtask do_image_wic after do_rootfs before do_build
 addtask do_create_ota_image_wic after do_image_wic do_image_complete do_rootfs before do_populate_lic_deploy do_build
 do_create_ota_image_wic[recrdeps] = "do_build"
 do_create_ota_image_wic[depends] += " \

--- a/conf/machine/include/rpi-ota-image.inc
+++ b/conf/machine/include/rpi-ota-image.inc
@@ -78,7 +78,8 @@ python do_create_ota_image_wic() {
     note("Compressed OTA image created successfully: {}".format(ota_tar_gz_path))
 }
 
-addtask do_create_ota_image_wic after do_image_complete before do_populate_lic_deploy
+addtask do_image_wic after do_image_complete do_rootfs before do_build
+addtask do_create_ota_image_wic after do_image_wic do_image_complete do_rootfs before do_populate_lic_deploy do_build
 do_create_ota_image_wic[recrdeps] = "do_build"
 do_create_ota_image_wic[depends] += " \
     virtual/kernel:do_deploy \


### PR DESCRIPTION
Reason for Change: when IPKs are consumed in non Vendor builds; the final WIC image creation task was not having any proper tasks which it could rely on to order itself. Added `do_image_wic` to have dependency on `do_rootfs` as well which will be preceeded by the IPK installation tasks. This ensures that the required artifacts (kernel, dtb etc) are in place when WIC tasks kicks in. Similarly `do_create_ota_image_wic` task also needs ordering matching `do_image_wic`. Since `do_create_ota_image_wic` is a custom task added by RDK; it would need odering dependency as same as `do_image_wic` for Vendor build environment as well.
Test Procedure: Verify build integrity and OTA file creation process.