### PR TITLE
RDKEMW-370 : Default font provider

### DIFF
--- a/recipes-workaround/ttf-fonts/liberation-fonts_%.bbappend
+++ b/recipes-workaround/ttf-fonts/liberation-fonts_%.bbappend
@@ -1,0 +1,2 @@
+RPROVIDES:${PN} = "virtual/default-font"
+RPROVIDES = "virtual/default-font"


### PR DESCRIPTION
Reason for change:rdk-fonts will be opensourced,currently it is packaged as rdm deployment.Once cleaned up, we can update in generic layer 
Test Procedure: fonts should be present in all builds 
Risks: Low
Priority: P1