### PR TITLE
Clean-up the systemaudioplayer from the rdkservices_git.bbappend

### DIFF
--- a/recipes-workaround/rdkservices/rdkservices_git.bbappend
+++ b/recipes-workaround/rdkservices/rdkservices_git.bbappend
@@ -1,4 +1,4 @@
-PACKAGECONFIG:remove = " xcast opencdmi_wv opencdmi_pr4 systemaudioplayer"
+PACKAGECONFIG:remove = " xcast opencdmi_wv opencdmi_pr4"
 
 # Remove when RDK-54147 is resolved
 EXTRA_OECMAKE:remove = " -DPLUGIN_RDKSHELL_READ_MAC_ON_STARTUP=ON"


### PR DESCRIPTION
Reason for change: Clean-up the systemaudioplayer from the rdkservices_git.bbappend.
Test Procedure: After removing the systemaudioplayer from the rdkservices_git.bbappend file check the middleware build is going fine
Risks: Low
Signed-off-by: Dorababu_Pragada@comcast.com