### PR TITLE
RDKVREFPLT-3298 : Remove workaround

### DIFF
--- a/recipes-workaround/rdkservices/rdkservices_git.bbappend
+++ b/recipes-workaround/rdkservices/rdkservices_git.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG:remove = " opencdmi_wv opencdmi_pr4"


### PR DESCRIPTION
Reason for change: Remove the recipe extension and use a variable instead.