### PR TITLE
REFPLTV-2600: add do_create_ota_image_wic to only image build target

### DIFF
--- a/conf/machine/include/rpi-ota-image.inc
+++ b/conf/machine/include/rpi-ota-image.inc
@@ -85,5 +85,12 @@ python do_create_ota_image_wic() {
     note("Removed intermediate OTA WIC file to save space: {}".format(ota_wic_image))
 }
 
-addtask do_image_wic after do_rootfs before do_build
-addtask do_create_ota_image_wic after do_image_wic do_image_complete do_rootfs before do_populate_lic_deploy do_build
+# Add the task only for image recipes
+python () {
+    if d.getVar('IMAGE_BASENAME'):
+        d.appendVarFlag('do_create_ota_image_wic', 'depends', 'do_image_wic')
+        d.appendVarFlag('do_create_ota_image_wic', 'after', 'do_image_wic')
+        d.appendVarFlag('do_create_ota_image_wic', 'before', 'do_populate_lic_deploy do_build')
+    else:
+        bb.note("do_create_ota_image_wic task not added as IMAGE_BASENAME is not set.")
+}


### PR DESCRIPTION
Reason for Change: OTA creation task was getting added to very package. Limit that to IMAGE recipe targets alone.