### PR TITLE
RDKVREFPLT-4456: add work-around to map PKGARCH to ripple

### DIFF
--- a/recipes-workaround/ripple/ripple_git.bbappend
+++ b/recipes-workaround/ripple/ripple_git.bbappend
@@ -1,0 +1,2 @@
+# TODO: RDKVREFPLT-4456: remove when PKG ARCK is part of upstream MW
+PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"


### PR DESCRIPTION
Hotfix added on top of vendor releasev4.0.3