### PR TITLE
RDKEMW-1163: remove ripple workaround since MW contains the fix

### DIFF
--- a/recipes-workaround/ripple/ripple_git.bbappend
+++ b/recipes-workaround/ripple/ripple_git.bbappend
@@ -1,2 +1,0 @@
-# TODO: RDKVREFPLT-4456: remove when PKG ARCK is part of upstream MW
-PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"


### PR DESCRIPTION
https://github.com/rdk-e/meta-middleware-generic-support/commit/e1f2ea71d2b88d74c1dc6ab0f431e02af197f21a