### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,7 @@
 name: "CLA"
+permissions:
+  contents: read
+  pull-requests: write
 on:
   issue_comment:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/rdkcentral/meta-vendor-raspberrypi-release/security/code-scanning/1](https://github.com/rdkcentral/meta-vendor-raspberrypi-release/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's purpose (handling pull requests and issue comments), the following permissions are likely sufficient:
- `contents: read` for reading repository contents.
- `pull-requests: write` for interacting with pull requests.

The `permissions` block should be added at the root level of the workflow to apply to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
