### PR TITLE
REFPLTV-3166: OTA WIC image creation task is failing when the build is triggered for the second time without a clean rebuild.

### DIFF
--- a/classes/rpi-rdkv-ota-wic.bbclass
+++ b/classes/rpi-rdkv-ota-wic.bbclass
@@ -15,6 +15,7 @@ python do_create_rdkv_ota_wic_image() {
 
     deploy_dir_image = d.getVar('DEPLOY_DIR_IMAGE')
     image_basename = d.getVar('IMAGE_NAME')
+    image_basename_var = d.getVar('IMAGE_BASENAME')
 
     note("DEPLOY_DIR_IMAGE: {}".format(deploy_dir_image))
     note("IMAGE_NAME: {}".format(image_basename))
@@ -87,6 +88,12 @@ python do_create_rdkv_ota_wic_image() {
     size_after = os.path.getsize(ota_wic_image)
     note("Size of {} after deleting partitions and truncating: {} bytes".format(ota_wic_image, size_after))
 
+    # Remove any previously created OTA archives for this image before creating a new one.
+    import glob
+    for old_ota in glob.glob(os.path.join(deploy_dir_image, image_basename_var + '*-ota.wic.tar.gz')):
+        note("Removing previously created OTA archive: {}".format(old_ota))
+        os.remove(old_ota)
+
     ota_tar_gz_path = os.path.join(deploy_dir_image, ota_tar_gz_name)
     with tarfile.open(ota_tar_gz_path, "w:gz") as tar:
         tar.add(ota_wic_image, arcname=os.path.basename(ota_wic_image))
@@ -97,10 +104,6 @@ python do_create_rdkv_ota_wic_image() {
     os.remove(ota_wic_image)
     note("Removed intermediate OTA WIC file to save space: {}".format(ota_wic_image))
 }
-
-# Exclude DATETIME and the timestamp-derived image name variables used by this
-# task to avoid basehash changes and re-signing on every parse.
-do_create_rdkv_ota_wic_image[vardepsexclude] += "DATETIME IMAGE_NAME OTA_IMAGE_NAME"
 
 addtask do_create_rdkv_ota_wic_image after do_image_complete do_rootfs before do_build
 

--- a/classes/rpi-rdkv-ota-wic.bbclass
+++ b/classes/rpi-rdkv-ota-wic.bbclass
@@ -90,7 +90,7 @@ python do_create_rdkv_ota_wic_image() {
     note("Size of {} after deleting partitions and truncating: {} bytes".format(ota_wic_image, size_after))
 
     # Remove any previously created OTA archives for this image.
-    # This must happen even when OTA creation is skipped.
+    # This cleanup runs only when generating a new OTA image.
     for old_ota in glob.glob(os.path.join(deploy_dir_image, image_basename_var + '*-ota.wic.tar.gz')):
         note("Removing previously created OTA archive: {}".format(old_ota))
         os.remove(old_ota)

--- a/classes/rpi-rdkv-ota-wic.bbclass
+++ b/classes/rpi-rdkv-ota-wic.bbclass
@@ -98,8 +98,9 @@ python do_create_rdkv_ota_wic_image() {
     note("Removed intermediate OTA WIC file to save space: {}".format(ota_wic_image))
 }
 
-# vardepsexclude for DATETIME — prevents the basehash-changed reparse error.
-do_create_rdkv_ota_wic_image[vardepsexclude] += "DATETIME"
+# Exclude DATETIME and the timestamp-derived image name variables used by this
+# task to avoid basehash changes and re-signing on every parse.
+do_create_rdkv_ota_wic_image[vardepsexclude] += "DATETIME IMAGE_NAME OTA_IMAGE_NAME"
 
 addtask do_create_rdkv_ota_wic_image after do_image_complete do_rootfs before do_build
 

--- a/classes/rpi-rdkv-ota-wic.bbclass
+++ b/classes/rpi-rdkv-ota-wic.bbclass
@@ -107,3 +107,24 @@ python do_create_rdkv_ota_wic_image() {
 }
 
 addtask do_create_rdkv_ota_wic_image after do_image_complete do_rootfs before do_build
+
+python do_clean_ota_wic_images() {
+    import glob
+    import os
+    from bb import note
+
+    deploy_dir_image = d.getVar('DEPLOY_DIR_IMAGE')
+    image_basename = d.getVar('IMAGE_BASENAME')
+
+    if not deploy_dir_image or not image_basename:
+        return
+
+    for old_ota in glob.glob(os.path.join(deploy_dir_image, image_basename + '*-ota.wic.tar.gz')):
+        note("Removing OTA archive: {}".format(old_ota))
+        try:
+            os.remove(old_ota)
+        except FileNotFoundError:
+            pass
+}
+
+do_clean[postfuncs] += "do_clean_ota_wic_images"

--- a/classes/rpi-rdkv-ota-wic.bbclass
+++ b/classes/rpi-rdkv-ota-wic.bbclass
@@ -30,7 +30,10 @@ python do_create_rdkv_ota_wic_image() {
     note("OTA_IMAGE_NAME: {}".format(ota_image_name))
     note("OTA_TAR_GZ_NAME: {}".format(ota_tar_gz_name))
 
-    # Find the generated WIC image
+    # Find the generated WIC image.
+    # Only match the exact IMAGE_NAME timestamp so that OTA is created only when
+    # a new .wic was actually produced. If the image was restored from sstate and
+    # no matching .wic exists for the current timestamp, skip silently.
     wic_image = None
     for file in os.listdir(deploy_dir_image):
         if file.startswith(image_basename) and file.endswith('.wic'):
@@ -38,7 +41,9 @@ python do_create_rdkv_ota_wic_image() {
             break
 
     if not wic_image:
-        fatal("Not able to find {}*.wic for OTA image creation.".format(image_basename))
+        note("No WIC image found matching '{}*.wic'. "
+             "Image was likely restored from sstate; skipping OTA creation.".format(image_basename))
+        return
 
     # Create a copy of the uncompressed WIC image
     ota_wic_image = os.path.join(deploy_dir_image, ota_image_name)
@@ -92,6 +97,9 @@ python do_create_rdkv_ota_wic_image() {
     os.remove(ota_wic_image)
     note("Removed intermediate OTA WIC file to save space: {}".format(ota_wic_image))
 }
+
+# vardepsexclude for DATETIME — prevents the basehash-changed reparse error.
+do_create_rdkv_ota_wic_image[vardepsexclude] += "DATETIME"
 
 addtask do_create_rdkv_ota_wic_image after do_image_complete do_rootfs before do_build
 

--- a/classes/rpi-rdkv-ota-wic.bbclass
+++ b/classes/rpi-rdkv-ota-wic.bbclass
@@ -94,7 +94,7 @@ python do_create_rdkv_ota_wic_image() {
     for old_ota in glob.glob(os.path.join(deploy_dir_image, image_basename_var + '*-ota.wic.tar.gz')):
         note("Removing previously created OTA archive: {}".format(old_ota))
         os.remove(old_ota)
-        
+
     ota_tar_gz_path = os.path.join(deploy_dir_image, ota_tar_gz_name)
     with tarfile.open(ota_tar_gz_path, "w:gz") as tar:
         tar.add(ota_wic_image, arcname=os.path.basename(ota_wic_image))

--- a/classes/rpi-rdkv-ota-wic.bbclass
+++ b/classes/rpi-rdkv-ota-wic.bbclass
@@ -8,6 +8,7 @@
 OTA_IMAGE_NAME ?= "${IMAGE_NAME}-ota.wic"
 
 python do_create_rdkv_ota_wic_image() {
+    import glob
     import os
     import subprocess
     import tarfile
@@ -88,12 +89,12 @@ python do_create_rdkv_ota_wic_image() {
     size_after = os.path.getsize(ota_wic_image)
     note("Size of {} after deleting partitions and truncating: {} bytes".format(ota_wic_image, size_after))
 
-    # Remove any previously created OTA archives for this image before creating a new one.
-    import glob
+    # Remove any previously created OTA archives for this image.
+    # This must happen even when OTA creation is skipped.
     for old_ota in glob.glob(os.path.join(deploy_dir_image, image_basename_var + '*-ota.wic.tar.gz')):
         note("Removing previously created OTA archive: {}".format(old_ota))
         os.remove(old_ota)
-
+        
     ota_tar_gz_path = os.path.join(deploy_dir_image, ota_tar_gz_name)
     with tarfile.open(ota_tar_gz_path, "w:gz") as tar:
         tar.add(ota_wic_image, arcname=os.path.basename(ota_wic_image))
@@ -106,4 +107,3 @@ python do_create_rdkv_ota_wic_image() {
 }
 
 addtask do_create_rdkv_ota_wic_image after do_image_complete do_rootfs before do_build
-


### PR DESCRIPTION
**Reason for change:** 
OTA WIC image creation task is failing when the build is triggered for the second time without a clean rebuild. So, we return the task when latest timestamp image is not available.
**Root cause:**
1. In failure log, IMAGE_NAME is lib32-middleware-test-image-RPI4-20260513133113, but no matching .wic exists for that timestamp.
2. Available artifacts are older timestamped files plus stable symlinks under IMAGE_LINK_NAME, for example lib32-middleware-test-image-raspberrypi4-64-rdke.wic -> older rootfs.wic.
3. Existing code was selecting only IMAGE_NAME*.wic, so rebuilds failed whenever timestamp advanced without new rootfs.wic at that exact name. 
**Test Procedure:** Build and verify.
**Risks:** Low.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com