### PR TITLE
RDKEVL-7225: The OTA image created are not getting removed when executing clean or cleanall build target.

### DIFF
--- a/classes/rpi-rdkv-ota-wic.bbclass
+++ b/classes/rpi-rdkv-ota-wic.bbclass
@@ -95,7 +95,7 @@ python do_create_rdkv_ota_wic_image() {
 
 addtask do_create_rdkv_ota_wic_image after do_image_complete do_rootfs before do_build
 
-python do_cleanall_ota_wic_images() {
+python do_clean_ota_wic_images() {
     import glob
     import os
     from bb import note
@@ -108,7 +108,10 @@ python do_cleanall_ota_wic_images() {
 
     for old_ota in glob.glob(os.path.join(deploy_dir_image, image_basename + '*-ota.wic.tar.gz')):
         note("cleanall removing OTA archive: {}".format(old_ota))
-        os.remove(old_ota)
+        try:
+            os.remove(old_ota)
+        except FileNotFoundError:
+            pass
 }
 
-do_clean[postfuncs] += "do_cleanall_ota_wic_images"
+do_clean[postfuncs] += "do_clean_ota_wic_images"

--- a/classes/rpi-rdkv-ota-wic.bbclass
+++ b/classes/rpi-rdkv-ota-wic.bbclass
@@ -95,3 +95,20 @@ python do_create_rdkv_ota_wic_image() {
 
 addtask do_create_rdkv_ota_wic_image after do_image_complete do_rootfs before do_build
 
+python do_cleanall_ota_wic_images() {
+    import glob
+    import os
+    from bb import note
+
+    deploy_dir_image = d.getVar('DEPLOY_DIR_IMAGE')
+    image_basename = d.getVar('IMAGE_BASENAME')
+
+    if not deploy_dir_image or not image_basename:
+        return
+
+    for old_ota in glob.glob(os.path.join(deploy_dir_image, image_basename + '*-ota.wic.tar.gz')):
+        note("cleanall removing OTA archive: {}".format(old_ota))
+        os.remove(old_ota)
+}
+
+do_clean[postfuncs] += "do_cleanall_ota_wic_images"

--- a/classes/rpi-rdkv-ota-wic.bbclass
+++ b/classes/rpi-rdkv-ota-wic.bbclass
@@ -107,7 +107,7 @@ python do_clean_ota_wic_images() {
         return
 
     for old_ota in glob.glob(os.path.join(deploy_dir_image, image_basename + '*-ota.wic.tar.gz')):
-        note("cleanall removing OTA archive: {}".format(old_ota))
+        note("Removing OTA archive: {}".format(old_ota))
         try:
             os.remove(old_ota)
         except FileNotFoundError:


### PR DESCRIPTION
**Reason for change:** Added the python function to delete the OTA image when doing the clean and cleanall command.
**Test Procedure:** Build and verify.
**Risks:** Low.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com